### PR TITLE
Update CSS selectors

### DIFF
--- a/public/lancer-initiative.css
+++ b/public/lancer-initiative.css
@@ -35,7 +35,7 @@ li.combatant.enemy {
   border-color: var(--lancer-initiative-enemy-color) !important;
 }
 
-#combat #combat-tracker .combatant .token-initiative {
+[data-tab=combat] #combat-tracker .combatant .token-initiative {
   padding-left: 0.5em;
   align-items: center;
   display: flex;
@@ -43,30 +43,30 @@ li.combatant.enemy {
   flex: 0 0 auto;
 }
 
-#combat #combat-tracker .combatant .token-initiative i,
-#combat #combat-tracker .combatant .token-initiative a {
+[data-tab=combat] #combat-tracker .combatant .token-initiative i,
+[data-tab=combat] #combat-tracker .combatant .token-initiative a {
   font-size: var(--lancer-initiative-icon-size);
 }
-#combat #combat-tracker .combatant .token-initiative i.done {
+[data-tab=combat] #combat-tracker .combatant .token-initiative i.done {
   color: var(--lancer-initiative-done-color);
 }
 
-#combat #combat-tracker .combatant.player .token-initiative a {
+[data-tab=combat] #combat-tracker .combatant.player .token-initiative a {
   color: var(--lancer-initiative-player-color);
 }
 
-#combat #combat-tracker .combatant.friendly .token-initiative a {
+[data-tab=combat] #combat-tracker .combatant.friendly .token-initiative a {
   color: var(--lancer-initiative-friendly-color);
 }
-#combat #combat-tracker .combatant.neutral .token-initiative a {
+[data-tab=combat] #combat-tracker .combatant.neutral .token-initiative a {
   color: var(--lancer-initiative-neutral-color);
 }
 
-#combat #combat-tracker .combatant.enemy .token-initiative a {
+[data-tab=combat] #combat-tracker .combatant.enemy .token-initiative a {
   color: var(--lancer-initiative-enemy-color);
 }
 
-#combat #combat-tracker li.combatant.turn-done {
+[data-tab=combat] #combat-tracker li.combatant.turn-done {
   color: inherit;
   text-decoration: inherit;
 }


### PR DESCRIPTION
At some point in the v10 lifecycle, the css was changed causing the selectors to no longer apply to the combat tracker popout.